### PR TITLE
New api standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM golang:1.23
 WORKDIR /usr/app/
 
 # when modules is used, downlaod stuff to image
-# COPY go.mod go.sum
-# RUN go mod download && go mod verify
+COPY ./src/go.mod ./src/go.mod
+COPY ./src/go.sum ./src/go.sum
+RUN go -C ./src mod download && go -C ./src mod  verify
 
 # Copy everything from this dir to our image at /usr/app
 COPY . .

--- a/Example Data/Server B/Example Data_B.ttl
+++ b/Example Data/Server B/Example Data_B.ttl
@@ -7,7 +7,7 @@ minecraft:Stick_Plank_made_Instance a minecraft:Stick ;
 	minecraft:obtainedBy minecraft:Stick_Planks_recipe_Instance .
 
 minecraft:Server_a a nodeOntology:Server ;
-	nodeOntology:hasIP a .	
+	nodeOntology:hasIP a .
 
 minecraft:Server_c a nodeOntology:Server ;	
 	nodeOntology:hasIP c .

--- a/Example Data/Server C/Example Data_C.ttl
+++ b/Example Data/Server C/Example Data_C.ttl
@@ -24,7 +24,7 @@ minecraft:Pickaxe_Instance_Gustav a minecraft:Pickaxe ;
 	nodeOntology:hasID 5 .
 
 minecraft:Server_a a nodeOntology:Server ;
-	nodeOntology:hasIP a .	
+	nodeOntology:hasIP a .
 
 minecraft:Server_b a nodeOntology:Server ;
 	nodeOntology:hasIP b .

--- a/README.md
+++ b/README.md
@@ -663,12 +663,33 @@ particularly those involving Unicode.
 
 ### Passing the query to dirent servers
 
+To pass data and queries to different servers an common protocol is needed, this is described bellow
+
+#### The Common Header
+
+The common header for all queries Include general information that is needed for the system.
+These include an magic to determine if its acutely an PETS query, Query type, an identifying UUID and TTL.
+The body to this header is determined by the type.
+
+There might be further changes to this standard to include multiple variable with authorizations tokens in further development. This would allow advanced functions such as to hide internal paths to non authorized users, but still propagate the query thru the network.
+
+```mermaid
+packet-beta
+title PETS common header
+0-31: "Magic 'PETS' "
+32-47: "PETS Type"
+48-63: "TTL"
+64-191: "Query identifier (UUID)"
+```
+
+#### Payload for recursive mermaid query (type 0x1)
+
 Since the data might not be stored on the same server,
 we need the ability to send the query to the next server and return the results.
 Each node that is not stored on the server has a ``false node`` with an edge labeled ``pointsToServer``.
 This edge allows us to obtain the contact information needed to forward the query.
 
-The query is then converted from its internal representation to a format suitable for transmission:
+The query is then converted from its internal representation to a format suitable for transmission in the payload, in this case a simple string:
 
 ``QueryString;NextNode;AlongEdge``
 
@@ -680,6 +701,7 @@ This information is sufficient to reconstruct the query and its state. In the cu
 
 <!-- something something error handling -->
 
+The return value when resving such an recust should be valid
 ## Webserver
 
 A webserver is beneficial for our system because it acts as a bridge between users and the linked data processing. It allows us to interact with our system from anywhere using a simple HTTP request and it provides a unified interface for querying and retrieving linked data.

--- a/src/go.mod
+++ b/src/go.mod
@@ -2,4 +2,7 @@ module pets
 
 go 1.23.3
 
-require github.com/TyphonHill/go-mermaid v0.0.0-20250205143201-8224247d16ec // indirect
+require (
+	github.com/TyphonHill/go-mermaid v0.0.0-20250205143201-8224247d16ec
+	github.com/google/uuid v1.6.0
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,2 +1,4 @@
 github.com/TyphonHill/go-mermaid v0.0.0-20250205143201-8224247d16ec h1:tkd+9PvMs2Qz/BPdmRUAipNqi164gwUib0PFxoCw9G4=
 github.com/TyphonHill/go-mermaid v0.0.0-20250205143201-8224247d16ec/go.mod h1:BqMEbKnr2HHpZ4lJJvGjL47v6rZAUpJcOaE/db1Ppwc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/src/main.go
+++ b/src/main.go
@@ -153,7 +153,9 @@ func sendQuery(queryString string) string {
 	// create a header of ttl = 100 and an uuid
 	header := make([]byte, 0, 32)
 	header = binary.BigEndian.AppendUint16(header, 100)
-	qid, _ := uuid.New().MarshalBinary()
+	tmp := uuid.New()
+	log.Printf("Created query with id %s", tmp.URN())
+	qid, _ := tmp.MarshalBinary()
 	header = append(header, qid...)
 
 	payload := strings.NewReader(queryString)

--- a/src/main.go
+++ b/src/main.go
@@ -36,11 +36,14 @@ func main() {
 		fmt.Printf("%s: %v\n", k, v)
 		fmt.Println("-----------------")
 	}
-	http.HandleFunc("/", handler) // servers the main HTML file
+	// servers the main HTML file
+	http.HandleFunc("/", handler)
 
-	http.HandleFunc("/api/submit", handleSubmit) // API endpoint to handle form submission
+	// API endpoint to handle form submission
+	http.HandleFunc("/api/submit", handleSubmit)
 
-	http.HandleFunc("/api/recq", queryHandler)
+	// handle PETS request
+	http.HandleFunc("/api/pets", queryHandler)
 
 	// create the server and listen to port 80
 	err := http.ListenAndServe(":80", nil)
@@ -59,7 +62,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// if this
+	// if this magic doesn't match
 	if !reflect.DeepEqual(redMagic[:], pathExpression.PetsMermaidQueryHeader[:4]) {
 		fmt.Fprint(w, "%% Bad magic")
 		return
@@ -73,10 +76,10 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if the type is not recursive mermaid, then write the error
 	if petsType != 1 {
 		fmt.Fprint(w, "%% types other than recursive mermaid is not implemented")
 		return
-
 	}
 
 	stream := io.Reader(r.Body)

--- a/src/pathExpression/query.go
+++ b/src/pathExpression/query.go
@@ -243,7 +243,7 @@ func RecursiveTraverse(q *QueryStruct, data map[string][]parse.DataEdge, res io.
 					if server_edge.EdgeName == "hasIP" {
 
 						stream := io.MultiReader(bytes.NewReader(PetsMermaidQueryHeader[:]), qRec.ToReader())
-
+						log.Printf("query following querydata to %s \n%s", server_edge.TargetName, qRec.DebugToString())
 						resp, err := http.Post("http://"+server_edge.TargetName+"/api/pets", "PETSQ", stream)
 						// TODO write error as valid mermaid
 						if err != nil {

--- a/src/pathExpression/query_test.go
+++ b/src/pathExpression/query_test.go
@@ -5,14 +5,17 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	p "pets/parse"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 )
 
-func TestBob(t *testing.T) {
-	data := map[string][]DataEdge{
+// This functions traverse the data and sees if the resulting mermaid matches the expected outcome
+// TODO, make the companions ignore the order of the mermaid
+func TestTraversal(t *testing.T) {
+	data := map[string][]p.DataEdge{
 		"s": {
 			{"pickaxe", "pickaxe"},
 		},
@@ -54,10 +57,14 @@ func TestBob(t *testing.T) {
 	}
 }
 
-func TestTraversalSingleStep(t *testing.T) {
+// This function test if traversal without converting from reader and back
+// outputs the same path as acutely doing the conversion.
+// The propose of this is to se if sending to other server is viable as
+// to send to another server requires it to be converted to a format that could be sent over the network
+func TestTraversalWithToReader(t *testing.T) {
 
 	// test data
-	data := map[string][]DataEdge{
+	data := map[string][]p.DataEdge{
 		"s": {
 			{"pickaxe", "pickaxe"},
 		},
@@ -89,19 +96,19 @@ func TestTraversalSingleStep(t *testing.T) {
 	internal_steps := make([]string, 0, 10)
 
 	// add starting point
-	internal_steps = append(internal_steps, qStart.NextNode)
+	internal_steps = append(internal_steps, qStart.nextNode)
 
 	// walk once and add step
 	q := qStart.next(data)[0]
-	internal_steps = append(internal_steps, q.NextNode)
+	internal_steps = append(internal_steps, q.nextNode)
 
 	// walk once and add step
 	q = q.next(data)[0]
-	internal_steps = append(internal_steps, q.NextNode)
+	internal_steps = append(internal_steps, q.nextNode)
 
 	// walk once and add step
 	q = q.next(data)[0]
-	internal_steps = append(internal_steps, q.NextNode)
+	internal_steps = append(internal_steps, q.nextNode)
 
 	// ================================
 	// Repeat but convert back and forth
@@ -109,7 +116,7 @@ func TestTraversalSingleStep(t *testing.T) {
 	server_steps := make([]string, 0, 10)
 
 	// add starting point
-	server_steps = append(server_steps, qStart.NextNode)
+	server_steps = append(server_steps, qStart.nextNode)
 
 	// walk once and add step
 	r := qStart.ToReader()
@@ -118,7 +125,7 @@ func TestTraversalSingleStep(t *testing.T) {
 		t.Fatal(err)
 	}
 	q = q.next(data)[0]
-	server_steps = append(server_steps, q.NextNode)
+	server_steps = append(server_steps, q.nextNode)
 
 	// walk once and add step
 	r = q.ToReader()
@@ -127,7 +134,7 @@ func TestTraversalSingleStep(t *testing.T) {
 		t.Fatal(err)
 	}
 	q = q.next(data)[0]
-	server_steps = append(server_steps, q.NextNode)
+	server_steps = append(server_steps, q.nextNode)
 
 	// walk once and add step
 	r = q.ToReader()
@@ -136,7 +143,7 @@ func TestTraversalSingleStep(t *testing.T) {
 		t.Fatal(err)
 	}
 	q = q.next(data)[0]
-	server_steps = append(server_steps, q.NextNode)
+	server_steps = append(server_steps, q.nextNode)
 
 	// ================================
 	// compare result

--- a/src/pathExpression/query_test.go
+++ b/src/pathExpression/query_test.go
@@ -1,0 +1,151 @@
+package pathExpression
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestBob(t *testing.T) {
+	data := map[string][]DataEdge{
+		"s": {
+			{"pickaxe", "pickaxe"},
+		},
+		"pickaxe": {
+			{"obtainedBy", "Pickaxe_From_Stick_And_Stone_Recipe"},
+		},
+		"Pickaxe_From_Stick_And_Stone_Recipe": {
+			{"hasInput", "Stick"},
+			{"hasInput", "Cobblestone"},
+		},
+	}
+	fmt.Printf("%v\n\n", data)
+
+	// create a header of ttl = 100 and an uuid
+	header := make([]byte, 0, 32)
+	header = binary.BigEndian.AppendUint16(header, 100)
+	qid, err := uuid.New().MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	header = append(header, qid...)
+
+	payload := strings.NewReader("s/pickaxe/{obtainedBy/hasInput}*")
+
+	stream := io.MultiReader(bytes.NewReader(header), payload)
+
+	q, err := QueryStructFromStream(&stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s\n\n", q.DebugToString())
+
+	result := TraverseQuery(&q, data)
+
+	expected := "s-->|pickaxe|pickaxe\npickaxe-->|obtainedBy|Pickaxe_From_Stick_And_Stone_Recipe\nPickaxe_From_Stick_And_Stone_Recipe-->|hasInput|Stick\nPickaxe_From_Stick_And_Stone_Recipe-->|hasInput|Cobblestone\n"
+	t.Log(result)
+	if expected != result {
+		t.Fatal("Result did not match expected value")
+	}
+}
+
+func TestTraversalSingleStep(t *testing.T) {
+
+	// test data
+	data := map[string][]DataEdge{
+		"s": {
+			{"pickaxe", "pickaxe"},
+		},
+		"pickaxe": {
+			{"obtainedBy", "Pickaxe_From_Stick_And_Stone_Recipe"},
+		},
+		"Pickaxe_From_Stick_And_Stone_Recipe": {
+			{"hasInput", "Stick"},
+			{"hasInput", "Cobblestone"},
+		},
+	}
+
+	// make a query
+	header := make([]byte, 0, 32)
+	header = binary.BigEndian.AppendUint16(header, 100)
+	qid, _ := uuid.New().MarshalBinary()
+	header = append(header, qid...)
+
+	payload := strings.NewReader("s/pickaxe/{obtainedBy/hasInput}*")
+
+	stream := io.MultiReader(bytes.NewReader(header), payload)
+
+	qStart, err := QueryStructFromStream(&stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// store the steps taken
+	internal_steps := make([]string, 0, 10)
+
+	// add starting point
+	internal_steps = append(internal_steps, qStart.NextNode)
+
+	// walk once and add step
+	q := qStart.next(data)[0]
+	internal_steps = append(internal_steps, q.NextNode)
+
+	// walk once and add step
+	q = q.next(data)[0]
+	internal_steps = append(internal_steps, q.NextNode)
+
+	// walk once and add step
+	q = q.next(data)[0]
+	internal_steps = append(internal_steps, q.NextNode)
+
+	// ================================
+	// Repeat but convert back and forth
+
+	server_steps := make([]string, 0, 10)
+
+	// add starting point
+	server_steps = append(server_steps, qStart.NextNode)
+
+	// walk once and add step
+	r := qStart.ToReader()
+	q, err = QueryStructFromStream(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.next(data)[0]
+	server_steps = append(server_steps, q.NextNode)
+
+	// walk once and add step
+	r = q.ToReader()
+	q, err = QueryStructFromStream(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.next(data)[0]
+	server_steps = append(server_steps, q.NextNode)
+
+	// walk once and add step
+	r = q.ToReader()
+	q, err = QueryStructFromStream(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q = q.next(data)[0]
+	server_steps = append(server_steps, q.NextNode)
+
+	// ================================
+	// compare result
+
+	for i := 0; i < 4; i++ {
+		if internal_steps[i] != server_steps[i] {
+			t.Fatalf("step %d, they are not equal %s != %s", i, internal_steps[i], server_steps[i])
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Overview
This implements the new api standard, now also described in the readme.
The new standard contains a 4byte magic, 2byte type, 2 byte TTL followed by 16 byte of query id, which should be a valid uuid.

The type 0x1, recursive mermaid, have the same payload as before and is treated the same with the exception that TTL is used as hard limit of amount of steps the query can take

There are some internal changes to make this work such as adding the methods from stream and to reader, which follow the new standard

There where also unit test implemented for the query struct and its methods ToReader, FromSteam and next 

## Other fixes
- The docker file was optimized to avoid downloading dependence when unnecessary
- Fixed a trailing tab in the example data that caused parsing to output wrong data.
- Added table on contents to readme, moved intruduction